### PR TITLE
Fix: Ensure thread-safe access to grouped dependencies in Inject module.

### DIFF
--- a/Sources/Inject/Inject.swift
+++ b/Sources/Inject/Inject.swift
@@ -60,14 +60,8 @@ open class InjectPropertyWrapper<Dependency, Parameters>: StorePropertyWrapper<I
      */
     open func register(_ dependency: Dependency?) {
         if let group {
-            var groupStorage: InjectStorage?
-            if let storage = storage.groups[group] {
-                groupStorage = storage
-            } else {
-                groupStorage = InjectStorage()
-                storage.groups[group] = groupStorage
-            }
-            groupStorage?.set(dependency, forKey: key)
+            let groupStorage = storage.storageForGroup(group)
+            groupStorage.set(dependency, forKey: key)
         } else {
             storage.set(dependency, forKey: key)
         }
@@ -118,9 +112,11 @@ open class InjectPropertyWrapper<Dependency, Parameters>: StorePropertyWrapper<I
      - Returns: Matching dependencies.
      */
     private func dependencies(_ errorClosureExecuted: Bool = false) throws -> [Any] {
-        if let group, let storage = storage.groups[group],
-           let dependencies = storage.array(forKey: key) {
-            return dependencies
+        if let group {
+            let groupStorage = storage.storageForGroup(group)
+            if let dependencies = groupStorage.array(forKey: key) {
+                return dependencies
+            }
         }
         if let dependencies = storage.array(forKey: key) {
             return dependencies

--- a/Sources/Inject/InjectStorage.swift
+++ b/Sources/Inject/InjectStorage.swift
@@ -24,4 +24,15 @@ open class InjectStorage: DelegatedStorage {
             storage[storeKey]?.append(dependency)
         }
     }
+
+    @StorageActor // Ensure it's explicitly on the same actor, though implied by class context
+    public func storageForGroup(_ groupKey: DependencyGroupKey) -> InjectStorage {
+        if let existingGroupStorage = self.groups[groupKey] {
+            return existingGroupStorage
+        } else {
+            let newGroupStorage = InjectStorage() // Same type as self
+            self.groups[groupKey] = newGroupStorage
+            return newGroupStorage
+        }
+    }
 }


### PR DESCRIPTION
I introduced an actor-isolated method `storageForGroup()` in `InjectStorage` to manage access and creation of group-specific storage instances. This resolves a race condition where concurrent registrations or resolutions of grouped dependencies could lead to data corruption.

`InjectPropertyWrapper` now uses this method, ensuring that all operations on grouped dependencies are serialized through the `StorageActor`.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update.
[ ] Bug fix.
[ ] New feature.
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
