### PR TITLE
Fix #40 (storage): make StorageActor.shared immutable

### DIFF
--- a/Sources/Storage/StorageActor.swift
+++ b/Sources/Storage/StorageActor.swift
@@ -1,5 +1,5 @@
 /// A global actor responsible for managing access and write operations in storage systems.
 @globalActor
 public actor StorageActor {
-    public static var shared = StorageActor()
+    public static let shared = StorageActor()
 }


### PR DESCRIPTION
Static property 'shared' is not concurrency-safe because it is non-isolated global shared mutable state.

Making the 'shared' property a 'let' instead of a 'var' ensures that it is immutable and thus concurrency-safe. This resolves the build error that occurs on Xcode 16 Beta 7.

**What is the purpose of this pull request?**

[ ] Documentation update.
[x] Bug fix.
[ ] New feature.
[ ] Other, please explain:

**Which issue (if any) does this pull request address?** #40

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexruperez/SecurePropertyStorage/41)
<!-- Reviewable:end -->
